### PR TITLE
TCP_DATA_BUFFER_SIZE

### DIFF
--- a/libClearCore/inc/EthernetTcp.h
+++ b/libClearCore/inc/EthernetTcp.h
@@ -35,7 +35,7 @@ namespace ClearCore {
 /** The maximum number of allowable client connections at any given time. **/
 #define CLIENT_MAX 8
 /** The size of the buffer to hold incoming TCP data, in bytes. **/
-#define TCP_DATA_BUFFER_SIZE 600
+#define TCP_DATA_BUFFER_SIZE 1460
 
 /**
     \brief A base class for an Ethernet TCP connection.


### PR DESCRIPTION
- Set `TCP_DATA_BUFFER_SIZE` to `1460`
  - It will now match `TCP_MSS` as configured in `LwIP/LwIP/port/include/lwipopts.h`
  - This is a typical Ethernet MTU-sized TCP payload